### PR TITLE
OrganizationID as a DLT Configuration Parameter

### DIFF
--- a/src/main/java/es/in2/blockchainconnector/configuration/ApplicationConfig.java
+++ b/src/main/java/es/in2/blockchainconnector/configuration/ApplicationConfig.java
@@ -1,0 +1,31 @@
+package es.in2.blockchainconnector.configuration;
+
+import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
+import es.in2.blockchainconnector.exception.HashCreationException;
+import es.in2.blockchainconnector.utils.Utils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.NoSuchAlgorithmException;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ApplicationConfig {
+
+    private final OperatorProperties operatorProperties;
+
+
+    @Bean
+    public String organizationIdHash() {
+        try {
+            return Utils.calculateSHA256Hash(operatorProperties.organizationId());
+        } catch (NoSuchAlgorithmException e) {
+            throw new HashCreationException("Error creating organizationId hash: " + e.getMessage());
+        }
+    }
+
+
+}

--- a/src/main/java/es/in2/blockchainconnector/configuration/DLTAdapterConfig.java
+++ b/src/main/java/es/in2/blockchainconnector/configuration/DLTAdapterConfig.java
@@ -4,13 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import es.in2.blockchainconnector.configuration.properties.BlockchainProperties;
 import es.in2.blockchainconnector.configuration.properties.DLTAdapterProperties;
-import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
 import es.in2.blockchainconnector.domain.BlockchainNodeDTO;
 import es.in2.blockchainconnector.domain.BlockchainNodeSubscriptionDTO;
 import es.in2.blockchainconnector.exception.BlockchainNodeSubscriptionException;
-import es.in2.blockchainconnector.exception.HashCreationException;
 import es.in2.blockchainconnector.exception.RequestErrorException;
-import es.in2.blockchainconnector.utils.Utils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +20,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.security.NoSuchAlgorithmException;
 
 import static es.in2.blockchainconnector.utils.Utils.APPLICATION_JSON;
 import static es.in2.blockchainconnector.utils.Utils.CONTENT_TYPE;
@@ -36,22 +32,13 @@ public class DLTAdapterConfig {
     private final ObjectMapper objectMapper;
     private final BlockchainProperties blockchainProperties;
     private final DLTAdapterProperties dltAdapterProperties;
-    private final OperatorProperties operatorProperties;
+    private final ApplicationConfig applicationConfig;
 
     @Bean
     public CookieManager cookieManager() {
         CookieManager cookieManager = new CookieManager();
         cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
         return cookieManager;
-    }
-
-    @Bean
-    public String organizationIdHash() {
-        try {
-            return Utils.calculateSHA256Hash(operatorProperties.organizationId());
-        } catch (NoSuchAlgorithmException e) {
-            throw new HashCreationException("Error creating organizationId hash: " + e.getMessage());
-        }
     }
 
     @Bean
@@ -80,7 +67,7 @@ public class DLTAdapterConfig {
             BlockchainNodeDTO blockchainNodeDTO = new BlockchainNodeDTO(
                     blockchainProperties.rpcAddress(),
                     blockchainProperties.userEthereumAddress(),
-                    organizationIdHash());
+                    applicationConfig.organizationIdHash());
             String body = objectMapper.writer().writeValueAsString(blockchainNodeDTO);
             log.debug(" > Blockchain Node Configuration: {}", body);
             requestCall(URI.create(url), body);

--- a/src/main/java/es/in2/blockchainconnector/configuration/DLTAdapterConfig.java
+++ b/src/main/java/es/in2/blockchainconnector/configuration/DLTAdapterConfig.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import es.in2.blockchainconnector.configuration.properties.BlockchainProperties;
 import es.in2.blockchainconnector.configuration.properties.DLTAdapterProperties;
+import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
 import es.in2.blockchainconnector.domain.BlockchainNodeDTO;
 import es.in2.blockchainconnector.domain.BlockchainNodeSubscriptionDTO;
 import es.in2.blockchainconnector.exception.BlockchainNodeSubscriptionException;
+import es.in2.blockchainconnector.exception.HashCreationException;
 import es.in2.blockchainconnector.exception.RequestErrorException;
+import es.in2.blockchainconnector.utils.Utils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +23,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.security.NoSuchAlgorithmException;
 
 import static es.in2.blockchainconnector.utils.Utils.APPLICATION_JSON;
 import static es.in2.blockchainconnector.utils.Utils.CONTENT_TYPE;
@@ -32,12 +36,22 @@ public class DLTAdapterConfig {
     private final ObjectMapper objectMapper;
     private final BlockchainProperties blockchainProperties;
     private final DLTAdapterProperties dltAdapterProperties;
+    private final OperatorProperties operatorProperties;
 
     @Bean
     public CookieManager cookieManager() {
         CookieManager cookieManager = new CookieManager();
         cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
         return cookieManager;
+    }
+
+    @Bean
+    public String organizationIdHash() {
+        try {
+            return Utils.calculateSHA256Hash(operatorProperties.organizationId());
+        } catch (NoSuchAlgorithmException e) {
+            throw new HashCreationException("Error creating organizationId hash: " + e.getMessage());
+        }
     }
 
     @Bean
@@ -65,7 +79,8 @@ public class DLTAdapterConfig {
             log.debug(" > Blockchain Node Configuration url: {}", url);
             BlockchainNodeDTO blockchainNodeDTO = new BlockchainNodeDTO(
                     blockchainProperties.rpcAddress(),
-                    blockchainProperties.userEthereumAddress());
+                    blockchainProperties.userEthereumAddress(),
+                    organizationIdHash());
             String body = objectMapper.writer().writeValueAsString(blockchainNodeDTO);
             log.debug(" > Blockchain Node Configuration: {}", body);
             requestCall(URI.create(url), body);

--- a/src/main/java/es/in2/blockchainconnector/domain/BlockchainNodeDTO.java
+++ b/src/main/java/es/in2/blockchainconnector/domain/BlockchainNodeDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record BlockchainNodeDTO(
         @JsonProperty("rpcAddress") String rpcAddress,
-        @JsonProperty("userEthereumAddress") String userEthereumAddress
+        @JsonProperty("userEthereumAddress") String userEthereumAddress,
+        @JsonProperty("iss") String organizationId
 ) {
 }

--- a/src/main/java/es/in2/blockchainconnector/exception/HashCreationException.java
+++ b/src/main/java/es/in2/blockchainconnector/exception/HashCreationException.java
@@ -1,0 +1,12 @@
+package es.in2.blockchainconnector.exception;
+
+public class HashCreationException extends RuntimeException {
+
+    public HashCreationException(String message) {
+        super(message);
+    }
+
+    public HashCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImpl.java
+++ b/src/main/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImpl.java
@@ -1,6 +1,6 @@
 package es.in2.blockchainconnector.service.impl;
 
-import es.in2.blockchainconnector.configuration.DLTAdapterConfig;
+import es.in2.blockchainconnector.configuration.ApplicationConfig;
 import es.in2.blockchainconnector.configuration.properties.BrokerProperties;
 import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
 import es.in2.blockchainconnector.domain.*;
@@ -31,7 +31,7 @@ public class BlockchainEventCreationServiceImpl implements BlockchainEventCreati
     private final OperatorProperties operatorProperties;
     private final BrokerProperties brokerProperties;
     private final TransactionService transactionService;
-    private final DLTAdapterConfig dltAdapterConfig;
+    private final ApplicationConfig applicationConfig;
 
     @Override
     public Mono<OnChainEvent> createBlockchainEvent(String processId, OnChainEventDTO onChainEventDTO) {
@@ -56,7 +56,7 @@ public class BlockchainEventCreationServiceImpl implements BlockchainEventCreati
                 // Build OnChainEvent
                 OnChainEvent onChainEvent = OnChainEvent.builder()
                         .eventType(onChainEventDTO.eventType())
-                        .organizationId(dltAdapterConfig.organizationIdHash())
+                        .organizationId(applicationConfig.organizationIdHash())
                         .dataLocation(dataLocation)
                         .metadata(List.of())
                         .build();

--- a/src/main/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImpl.java
+++ b/src/main/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImpl.java
@@ -1,5 +1,6 @@
 package es.in2.blockchainconnector.service.impl;
 
+import es.in2.blockchainconnector.configuration.DLTAdapterConfig;
 import es.in2.blockchainconnector.configuration.properties.BrokerProperties;
 import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
 import es.in2.blockchainconnector.domain.*;
@@ -30,6 +31,7 @@ public class BlockchainEventCreationServiceImpl implements BlockchainEventCreati
     private final OperatorProperties operatorProperties;
     private final BrokerProperties brokerProperties;
     private final TransactionService transactionService;
+    private final DLTAdapterConfig dltAdapterConfig;
 
     @Override
     public Mono<OnChainEvent> createBlockchainEvent(String processId, OnChainEventDTO onChainEventDTO) {
@@ -54,7 +56,7 @@ public class BlockchainEventCreationServiceImpl implements BlockchainEventCreati
                 // Build OnChainEvent
                 OnChainEvent onChainEvent = OnChainEvent.builder()
                         .eventType(onChainEventDTO.eventType())
-                        .organizationId(Utils.calculateSHA256Hash(operatorProperties.organizationId()))
+                        .organizationId(dltAdapterConfig.organizationIdHash())
                         .dataLocation(dataLocation)
                         .metadata(List.of())
                         .build();

--- a/src/test/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImplTest.java
+++ b/src/test/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImplTest.java
@@ -1,6 +1,6 @@
 package es.in2.blockchainconnector.service.impl;
 
-import es.in2.blockchainconnector.configuration.DLTAdapterConfig;
+import es.in2.blockchainconnector.configuration.ApplicationConfig;
 import es.in2.blockchainconnector.configuration.properties.BrokerPathProperties;
 import es.in2.blockchainconnector.configuration.properties.BrokerProperties;
 import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
@@ -26,7 +26,7 @@ class BlockchainEventCreationServiceImplTest {
     private TransactionService transactionService;
 
     @Mock
-    private DLTAdapterConfig dltAdapterConfig;
+    private ApplicationConfig applicationConfig;
 
     @InjectMocks
     private BlockchainEventCreationServiceImpl service;
@@ -36,7 +36,7 @@ class BlockchainEventCreationServiceImplTest {
         MockitoAnnotations.openMocks(this);
         OperatorProperties operatorProperties = new OperatorProperties("VATES-878958");
         BrokerProperties brokerProperties = new BrokerProperties("http://localhost:1026", "http://localhost:1026", new BrokerPathProperties("/v2", "/entities"));
-        service = new BlockchainEventCreationServiceImpl(operatorProperties, brokerProperties, transactionService, dltAdapterConfig);
+        service = new BlockchainEventCreationServiceImpl(operatorProperties, brokerProperties, transactionService, applicationConfig);
 
     }
 

--- a/src/test/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImplTest.java
+++ b/src/test/java/es/in2/blockchainconnector/service/impl/BlockchainEventCreationServiceImplTest.java
@@ -1,5 +1,6 @@
 package es.in2.blockchainconnector.service.impl;
 
+import es.in2.blockchainconnector.configuration.DLTAdapterConfig;
 import es.in2.blockchainconnector.configuration.properties.BrokerPathProperties;
 import es.in2.blockchainconnector.configuration.properties.BrokerProperties;
 import es.in2.blockchainconnector.configuration.properties.OperatorProperties;
@@ -24,6 +25,9 @@ class BlockchainEventCreationServiceImplTest {
     @Mock
     private TransactionService transactionService;
 
+    @Mock
+    private DLTAdapterConfig dltAdapterConfig;
+
     @InjectMocks
     private BlockchainEventCreationServiceImpl service;
 
@@ -32,7 +36,7 @@ class BlockchainEventCreationServiceImplTest {
         MockitoAnnotations.openMocks(this);
         OperatorProperties operatorProperties = new OperatorProperties("VATES-878958");
         BrokerProperties brokerProperties = new BrokerProperties("http://localhost:1026", "http://localhost:1026", new BrokerPathProperties("/v2", "/entities"));
-        service = new BlockchainEventCreationServiceImpl(operatorProperties, brokerProperties, transactionService);
+        service = new BlockchainEventCreationServiceImpl(operatorProperties, brokerProperties, transactionService, dltAdapterConfig);
 
     }
 


### PR DESCRIPTION
ADD:
Added organizationID field on BlockchainNodeDTO
New HashCreationException for general hash creation error purposes Added a new bean on DLTAdapterConfig that creates a organizationIDHash CHANGE:
Changed service classes to adapt to the new changes Changed a test to adapt to the new changes